### PR TITLE
Fix psr-4 warning

### DIFF
--- a/tests/Unit/Actions/SendVerificationMailTest.php
+++ b/tests/Unit/Actions/SendVerificationMailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Actions;
 
 use App\Actions\SendVerificationMailAction;
 use App\Exceptions\UserAlreadyVerifiedException;


### PR DESCRIPTION
`Class Tests\Unit\SendVerificationMailTest located in ./tests/Unit/Actions/SendVerificationMailTest.php does not comply with psr-4 autoloading standard. Skipping.`