### PR TITLE
Update tailwinds/forms to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "@inertiajs/inertia": "^0.11.0",
         "@inertiajs/inertia-vue3": "^0.6.0",
         "@inertiajs/progress": "^0.2.6",
-        "@tailwindcss/forms": "^0.4.0",
+        "@tailwindcss/forms": "^0.5.3",
         "@vue/compiler-sfc": "^3.2.30",
         "autoprefixer": "^10.4.5",
         "cross-env": "^5.0.1",


### PR DESCRIPTION
Fix 6 warnings:
`autoprefixer: Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.`

https://github.com/tailwindlabs/tailwindcss/issues/8256#issuecomment-1124644438