### PR TITLE
Fix styling for Tag when using Light theme

### DIFF
--- a/resources/js/Components/Partials/Tag.vue
+++ b/resources/js/Components/Partials/Tag.vue
@@ -1,5 +1,11 @@
 <template>
-    <span :style="'background:#'+tag.color"><i class="fas fa-tag fa-xs"></i> {{ tag.name }}</span>
+    <div class="flex items-center dark:text-gray-500">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+            <path d="M9.16667 2.5L16.6667 10C17.0911 10.4745 17.0911 11.1922 16.6667 11.6667L11.6667 16.6667C11.1922 17.0911 10.4745 17.0911 10 16.6667L2.5 9.16667V5.83333C2.5 3.99238 3.99238 2.5 5.83333 2.5H9.16667" :stroke="'#'+ tag.color" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
+            <circle cx="7.50004" cy="7.49967" r="1.66667" :stroke="'#'+ tag.color" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></circle>
+        </svg>
+        <p class="ml-1">{{ tag.name }}</p>
+    </div>
 </template>
 
 <script setup>
@@ -7,12 +13,3 @@
         tag: Object
     });
 </script>
-<style scoped>
-    span {
-        border-radius: 5px;
-        color: #FFF;
-        padding: 5px 10px;
-        font-size: 14px;
-        font-weight: 600;
-    }
-</style>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -13,7 +13,7 @@
             <div v-if="mostExpensiveTags.length > 0" class="box mt-3">
                 <div class="box__section box__section--header">{{ trans('activities.tag.most_expensive') }}</div>
                 <div v-for="(tag) in mostExpensiveTags" class="box__section row row--seperate">
-                    <div class="row__column row__column--middle color-dark">
+                    <div class="row__column row__column--middle">
                         <Tag :tag="tag"></Tag>
                     </div>
                     <div class="row__column row__column--middle">

--- a/resources/js/Pages/Tags/Index.vue
+++ b/resources/js/Pages/Tags/Index.vue
@@ -18,18 +18,12 @@
                         <tbody>
                         <template v-for="tag in tags" class="box__section row">
                             <tr tabindex="0" class="focus:outline-none h-16 border-y border-gray-100 dark:border-gray-700 rounded">
-                                <td class="px-1 w-5/12">
-                                    <div class="flex items-center dark:text-gray-500">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
-                                            <path d="M9.16667 2.5L16.6667 10C17.0911 10.4745 17.0911 11.1922 16.6667 11.6667L11.6667 16.6667C11.1922 17.0911 10.4745 17.0911 10 16.6667L2.5 9.16667V5.83333C2.5 3.99238 3.99238 2.5 5.83333 2.5H9.16667" :stroke="'#'+ tag.color" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></path>
-                                            <circle cx="7.50004" cy="7.49967" r="1.66667" :stroke="'#'+ tag.color" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"></circle>
-                                        </svg>
-                                        <p class="ml-1">{{ tag.name }}</p>
-                                    </div>
+                                <td class="px-3 w-5/12">
+                                    <Tag :tag="tag"></Tag>
                                 </td>
                                 <td class="px-3 w-5/12">
                                     <div class="flex items-center dark:text-gray-500">
-                                        {{ trans('models.spendings') }} : {{ tag.spendings.length }}
+                                        {{ trans('models.spendings') }}: {{ tag.spendings.length }}
                                     </div>
                                 </td>
                                 <td class="px-3 text-center w-2/12">
@@ -58,6 +52,7 @@
     import { trans } from 'matice';
     import BreezeAuthenticatedLayout from '@/Layouts/Authenticated.vue';
     import EmptyState from "@/Components/Partials/EmptyState";
+    import Tag from '@/Components/Partials/Tag.vue';
     import {Inertia} from "@inertiajs/inertia";
 
     defineProps({


### PR DESCRIPTION
When using the Light theme, you couldn't see the Tags:
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/12570668/202238382-068a2651-198b-4db5-bc76-7a45f329428f.png">

<img width="1230" alt="image" src="https://user-images.githubusercontent.com/12570668/202238459-e4a350e5-3960-47a2-9bff-562785df9eac.png">

When investigating this issue, it seemed that the Tag partial wasn't used at all places. This is fixed now:
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/12570668/202238689-218b8dc0-3e65-4785-8863-61fc3a347660.png">

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/12570668/202238769-8792b1e6-c9a5-499f-b984-1bd523c496df.png">
