### PR TITLE
Use default Laravel error pages

### DIFF
--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,3 +1,0 @@
-<div style="text-align: center;" class="wrapper wrapper--narrow my-3">
-    <h2 class="text-center">403</h2>
-</div>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,3 +1,0 @@
-<div style="text-align: center;" class="wrapper wrapper--narrow my-3">
-    <h2 class="text-center">404</h2>
-</div>


### PR DESCRIPTION
When using the deleted blade-files, the error pages looked like this:
<img width="2558" alt="image" src="https://user-images.githubusercontent.com/12570668/202402196-1f7d01e7-2597-4db6-8be7-ca55eb96d745.png">

After removing these files, they look like:
<img width="592" alt="image" src="https://user-images.githubusercontent.com/12570668/202402241-be88e01a-f3c7-4832-812e-893a6a37f949.png">
