### PR TITLE
Revert `yarn.lock` when installing using `npm`

### DIFF
--- a/app/Console/Commands/BudgetInstall.php
+++ b/app/Console/Commands/BudgetInstall.php
@@ -49,7 +49,7 @@ class BudgetInstall extends Command
             $nodePackageManager = $this->choice('Which package manager would you like to use for Node.js?', [
                 'npm',
                 'yarn',
-            ]);
+            ], 0);
         }
 
         if (!$this->programExists($nodePackageManager)) {
@@ -57,6 +57,10 @@ class BudgetInstall extends Command
         } else {
             $this->info('Installing Node.js packages');
             $this->executeCommand([$nodePackageManager, 'install']);
+
+            if ($nodePackageManager === 'npm') {
+                $this->executeCommand(['git', 'restore', 'yarn.lock']);
+            }
 
             $this->info('Compiling front-end assets');
             $this->executeCommand([$nodePackageManager, 'run', 'production']);


### PR DESCRIPTION
Also made `npm` the default when running `php artisan budget:install`

Closes #73 